### PR TITLE
Fix hhtml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
          }         
          stage('Upload to AWS') {
               steps {
-                  withAWS(region:'eu-central-1',credentials:'aws-static') {
+                  withAWS(region:'eu-central-1',credentials:'devops') {
                   sh 'echo "Uploading content with AWS creds"'
                       s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'index.html', bucket:'jenkins-test-999')
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
          }         
          stage('Upload to AWS') {
               steps {
-                  withAWS(region:'eu-central-1',credentials:'AKIAZLPDXHVMNK2WHBEG') {
+                  withAWS(region:'eu-central-1',credentials:'devops') {
                   sh 'echo "Uploading content with AWS creds"'
                       s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'index.html', bucket:'jenkins-test-999')
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
          }         
          stage('Upload to AWS') {
               steps {
-                  withAWS(region:'eu-central-1',credentials:'devops') {
+                  withAWS(region:'eu-central-1',credentials:'AKIAZLPDXHVMNK2WHBEG') {
                   sh 'echo "Uploading content with AWS creds"'
                       s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'index.html', bucket:'jenkins-test-999')
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,10 @@ pipeline {
               steps {
                  aquaMicroscanner imageName: 'alpine:latest', notCompliesCmd: 'exit 1', onDisallowed: 'fail', outputFormat: 'html' 
               }
-	}         
+         }         
          stage('Upload to AWS') {
               steps {
-                  withAWS(region:'us-east-2',credentials:'aws-static') {
+                  withAWS(region:'eu-central-1',credentials:'aws-static') {
                   sh 'echo "Uploading content with AWS creds"'
                       s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'index.html', bucket:'static-jenkins-pipeline')
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
               steps {
                   withAWS(region:'eu-central-1',credentials:'aws-static') {
                   sh 'echo "Uploading content with AWS creds"'
-                      s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'index.html', bucket:'static-jenkins-pipeline')
+                      s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'index.html', bucket:'jenkins-test-999')
                   }
               }
          }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,11 +15,11 @@ pipeline {
                   sh 'tidy -q -e *.html'
               }
          }
-         stage('Security Scan') {
-              steps { 
-                 aquaMicroscanner imageName: 'alpine:latest', notCompleted: 'exit 1', onDisallowed: 'fail'
+	stage('Security Scan') {
+              steps {
+                 aquaMicroscanner imageName: 'alpine:latest', notCompliesCmd: 'exit 1', onDisallowed: 'fail', outputFormat: 'html' 
               }
-         }         
+	}         
          stage('Upload to AWS') {
               steps {
                   withAWS(region:'us-east-2',credentials:'aws-static') {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <title>Static HTML Site</title>
       </head>
       <body>
-        <p>This is the first paragraph in a simple Static HTML site. There is no <strong>CSS</strong> or <strong>JavaScript</strong>.</p>
+        <p>This is the first paragraph in a simple Static HTML site. There is no Balazs <strong>CSS</strong> or <strong>JavaScript</strong>.</p>
       </body>
     </html>
 


### PR DESCRIPTION
- security stage fixed (aqua microscanner configuration - watch out for correct whitespace and tab 
stage('Security Scan') {
              steps {
                 aquaMicroscanner imageName: 'alpine:latest', notCompliesCmd: 'exit 1', onDisallowed: 'fail', outputFormat: 'html' 
              }
}

- AWS S3 upload stage: configure the conncection manager by adding the AWS access and security keys 